### PR TITLE
Escape backslash, tab and newline in char literals

### DIFF
--- a/src/Elm/Pretty.elm
+++ b/src/Elm/Pretty.elm
@@ -1678,8 +1678,17 @@ escape val =
 escapeChar : Char -> String
 escapeChar val =
     case val of
+        '\\' ->
+            "\\\\"
+
         '\'' ->
             "\\'"
+
+        '\t' ->
+            "\\t"
+
+        '\n' ->
+            "\\n"
 
         c ->
             String.fromChar c


### PR DESCRIPTION
This fixes a bug in `escapeChar` with char literal `\` (backslash). It currently generates `'\'` which makes the whole file syntactically wrong because the ending quote is escaped. This generates `'\\'` instead.

I also added `\t` and `\n` to keep `escapeChar` consistent with `escape`.

Another possibility: add the single quote `'` to the characters escaped in `escape`, and make `escapeChar` simply call `escape` after transforming the Char to a String:

```elm
escapeChar : Char -> String
escapeChar =
    String.fromChar >> escape
``` 


See also https://github.com/stil4m/elm-syntax/pull/125/files and https://github.com/stil4m/elm-syntax/issues/124