### PR TITLE
Fix invalid printing of hex patterns, leading to invalid generated code

### DIFF
--- a/src/Elm/Pretty.elm
+++ b/src/Elm/Pretty.elm
@@ -631,7 +631,7 @@ prettyPatternInner isTop pattern =
             Pretty.string (String.fromInt val)
 
         HexPattern val ->
-            Pretty.string (Hex.toString val)
+            Pretty.string (toHexString val)
 
         FloatPattern val ->
             Pretty.string (String.fromFloat val)


### PR DESCRIPTION
Currently, hex patterns are replaced simply by a lowercase printing of the hex digits (without zero padding or a leading `0x`).  This leads to code that very likely will not compile, as the hex pattern will either become a var pattern (if the hex is a valid identifier) or just be a compilation error.

For example, currently:

```elm
case i of
    0x0F -> "16"
    _ -> "_"
```

will become

```elm
case i of
    f ->
        "16"

    _ ->
        "_"
```

This was due to directly using `Hex.toString` instead of `toHexString` in printing hex patterns.