### PR TITLE
Correct printing of \r and \u{hex code} strings and chars

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ elmAsString =
 ### Known deviations from `elm-format`:
 
 * Float literals not getting a .0 added at the end.
-* Unicode characters.
 * Type annotations on functions sometimes split onto next line without being
 broken themselves.
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 ## Version 6.0.3
 
-Corrected printing \r and \u{hex code} strings.
+Corrected printing \r and \u{hex code} strings and characters.
 
 ## Version 6.0.2
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,3 +1,7 @@
+## Version 6.0.3
+
+Corrected printing \r and \u{hex code} strings.
+
 ## Version 6.0.2
 
 Corrected the definition of the not equals binary operator (was typo "1/", corrected to "/=").

--- a/elm.json
+++ b/elm.json
@@ -15,9 +15,12 @@
         "elm/core": "1.0.0 <= v < 2.0.0",
         "elm/parser": "1.1.0 <= v < 2.0.0",
         "elm-community/maybe-extra": "5.0.0 <= v < 6.0.0",
+        "miniBill/elm-unicode": "1.1.1 <= v < 2.0.0",
         "rtfeldman/elm-hex": "1.0.0 <= v < 2.0.0",
         "stil4m/elm-syntax": "7.1.0 <= v < 8.0.0",
         "the-sett/elm-pretty-printer": "3.0.0 <= v < 4.0.0"
     },
-    "test-dependencies": {}
+    "test-dependencies": {
+        "elm-explorations/test": "2.2.0 <= v < 3.0.0"
+    }
 }

--- a/src/Elm/Pretty.elm
+++ b/src/Elm/Pretty.elm
@@ -1793,6 +1793,32 @@ escape val =
         |> hexEscapeNonPrintCharacters
 
 
+escapeChar : Char -> String
+escapeChar character =
+    case character of
+        '\\' ->
+            "\\\\"
+
+        '\'' ->
+            "\\'"
+
+        '\t' ->
+            "\\t"
+
+        '\n' ->
+            "\\n"
+
+        '\u{000D}' ->
+            "\\u{000D}"
+
+        otherCharacter ->
+            if characterIsPrint otherCharacter then
+                "\\u{" ++ characterHex otherCharacter ++ "}"
+
+            else
+                String.fromChar otherCharacter
+
+
 hexEscapeNonPrintCharacters : String -> String
 hexEscapeNonPrintCharacters val =
     val
@@ -1844,25 +1870,6 @@ characterIsPrint character =
 
                 _ ->
                     False
-
-
-escapeChar : Char -> String
-escapeChar val =
-    case val of
-        '\\' ->
-            "\\\\"
-
-        '\'' ->
-            "\\'"
-
-        '\t' ->
-            "\\t"
-
-        '\n' ->
-            "\\n"
-
-        c ->
-            String.fromChar c
 
 
 optionalGroup : Bool -> Doc Tag -> Doc Tag

--- a/src/Elm/Pretty.elm
+++ b/src/Elm/Pretty.elm
@@ -85,6 +85,7 @@ import Hex
 import ImportsAndExposing
 import Parser exposing (Parser)
 import Pretty exposing (Doc)
+import Unicode
 import Util exposing (denode, denodeAll, denodeMaybe, nodify, nodifyAll)
 
 
@@ -1788,6 +1789,61 @@ escape val =
         |> String.replace "\"" "\\\""
         |> String.replace "\n" "\\n"
         |> String.replace "\t" "\\t"
+        |> String.replace "\u{000D}" "\\u{000D}"
+        |> hexEscapeNonPrintCharacters
+
+
+hexEscapeNonPrintCharacters : String -> String
+hexEscapeNonPrintCharacters val =
+    val
+        |> String.toList
+        |> List.map
+            (\character ->
+                if characterIsPrint character then
+                    "\\u{" ++ characterHex character ++ "}"
+
+                else
+                    String.fromChar character
+            )
+        |> String.concat
+
+
+characterHex : Char -> String
+characterHex character =
+    String.toUpper (Hex.toString (Char.toCode character))
+
+
+characterIsPrint : Char -> Bool
+characterIsPrint character =
+    case Unicode.getCategory character of
+        Nothing ->
+            False
+
+        Just category ->
+            case category of
+                Unicode.SeparatorLine ->
+                    True
+
+                Unicode.SeparatorParagraph ->
+                    True
+
+                Unicode.OtherControl ->
+                    True
+
+                Unicode.OtherFormat ->
+                    True
+
+                Unicode.OtherSurrogate ->
+                    True
+
+                Unicode.OtherPrivateUse ->
+                    True
+
+                Unicode.OtherNotAssigned ->
+                    True
+
+                _ ->
+                    False
 
 
 escapeChar : Char -> String

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -9,8 +9,36 @@ import Test exposing (Test)
 
 tests : Test
 tests =
-    Test.describe "escape sequence in `Elm.CodeGen.string` sometimes isn't escaped in pretty printed expression"
-        [ Test.test "string with escaped carriage return is pretty printed correctly"
+    Test.describe "escape sequence in literal characters sometimes isn't escaped in pretty printed expression"
+        [ Test.test "string with escaped line break is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.string "\n"
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "\"\\n\""
+            )
+        , Test.test "string with escaped tab break is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.string "\t"
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "\"\\t\""
+            )
+        , Test.test "string with escaped backslash return is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.string "\\"
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "\"\\\\\""
+            )
+        , Test.test "string with escaped double quote is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.string "\""
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "\"\\\"\""
+            )
+        , Test.test "string with escaped carriage return is pretty printed correctly"
             (\() ->
                 Elm.CodeGen.string "\u{000D}"
                     |> Elm.Pretty.prettyExpression
@@ -24,5 +52,54 @@ tests =
                     |> Pretty.pretty 100
                     |> String.toList
                     |> Expect.equalLists ("\"👩\\u{200D}🚒\"" |> String.toList)
+            )
+        , Test.test "char with escaped line break is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.char '\n'
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "'\\n'"
+            )
+        , Test.test "char with escaped tab is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.char '\t'
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "'\\t'"
+            )
+        , Test.test "char with escaped backslash is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.char '\\'
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "'\\\\'"
+            )
+        , Test.test "char with escaped single quote is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.char '\''
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "'\\''"
+            )
+        , Test.test "char with escaped double quote is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.char '"'
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "'\"'"
+            )
+        , Test.test "char with escaped code 200D is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.char '\u{200D}'
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "'\\u{200D}'"
+            )
+        , Test.test "char with escaped carriage return is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.char '\u{000D}'
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "'\\u{000D}'"
             )
         ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -1,0 +1,28 @@
+module Tests exposing (tests)
+
+import Elm.CodeGen
+import Elm.Pretty
+import Expect
+import Pretty
+import Test exposing (Test)
+
+
+tests : Test
+tests =
+    Test.describe "escape sequence in `Elm.CodeGen.string` sometimes isn't escaped in pretty printed expression"
+        [ Test.test "string with escaped carriage return is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.string "\u{000D}"
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> Expect.equal "\"\\u{000D}\""
+            )
+        , Test.test "string with escaped combo emoji is pretty printed correctly"
+            (\() ->
+                Elm.CodeGen.string "👩\u{200D}🚒"
+                    |> Elm.Pretty.prettyExpression
+                    |> Pretty.pretty 100
+                    |> String.toList
+                    |> Expect.equalLists ("\"👩\\u{200D}🚒\"" |> String.toList)
+            )
+        ]


### PR DESCRIPTION
fixes #50.

The fix adds an extra dependency to to determine categories: https://dark.elm.dmy.fr/packages/miniBill/elm-unicode/latest/